### PR TITLE
feat: make useLocation parameters generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -565,8 +565,8 @@ export declare const routeLoaderQrl: LoaderConstructorQRL;
 /**
  * @public
  */
-export declare interface RouteLocation {
-    readonly params: Readonly<Record<string, string>>;
+export declare interface RouteLocation<Params = Record<string, string>> {
+    readonly params: Readonly<Params>;
     readonly url: URL;
     readonly isNavigating: boolean;
     readonly prevUrl: URL | undefined;
@@ -693,7 +693,7 @@ export declare const useDocumentHead: () => Required<ResolvedDocumentHead>;
 /**
  * @public
  */
-export declare const useLocation: () => RouteLocation;
+export declare const useLocation: <Params = unknown>() => RouteLocation<Params>;
 
 /**
  * @public


### PR DESCRIPTION
Now `useLocation` supports generic type for `Params`.

```ts
// path: `src/routes/sku/[skuId]/index.tsx`

import { component$ } from '@builder.io/qwik';
import { useLocation } from '@builder.io/qwik-city';
 
export default component$(() => {
  const loc = useLocation<{ skuId: string }>();
 
  return (
    <>
      <h1>SKU</h1>
      {loc.isNavigating && <p>Loading...</p>}
      <p>pathname: {loc.url.pathname}</p>
      <p>skuId: {loc.params.skuId}</p>
    </>
  );
});
```